### PR TITLE
reservation time datatype fixed and missing comma in accounting json

### DIFF
--- a/models/reservation.js
+++ b/models/reservation.js
@@ -21,11 +21,11 @@ reservation.init(
     },
     start_dt:{
 
-        type: DataTypes.DATETIME,
+        type: DataTypes.DATE,
         allowNull: true,
     },
     end_dt:{
-        type: DataTypes.DATETIME,
+        type: DataTypes.DATE,
         allowNull: true,
 
     },

--- a/seeds/accountingData.json
+++ b/seeds/accountingData.json
@@ -79,7 +79,7 @@
         "ccv" : "",
         "card_zipcode" : "49684",
         "customer_id" : "9"
-    }
+    },
     {
         "cardholder_name" : "Kathleen V. Dutton",
         "card_type" : "MasterCard",


### PR DESCRIPTION
Start and end time needed to be Date datatype, not date-time.
Comma missing from final seed file in the reservation.